### PR TITLE
Allow vertically-inversed enemies to spawn

### DIFF
--- a/NPCs/BigCoreCustom.cs
+++ b/NPCs/BigCoreCustom.cs
@@ -143,6 +143,7 @@ namespace ChensGradiusMod.NPCs
 
     public override void SendExtraAI(BinaryWriter writer)
     {
+      base.SendExtraAI(writer);
       writer.Write((byte)mode);
       writer.Write(npc.target);
       writer.Write(regularAssaultDirection);
@@ -151,6 +152,7 @@ namespace ChensGradiusMod.NPCs
 
     public override void ReceiveExtraAI(BinaryReader reader)
     {
+      base.ReceiveExtraAI(reader);
       mode = (States)reader.ReadByte();
       npc.target = reader.ReadInt32();
       regularAssaultDirection = reader.ReadSByte();
@@ -159,7 +161,7 @@ namespace ChensGradiusMod.NPCs
 
     protected override Types EnemyType => Types.Boss;
 
-    protected override int FrameSpeed { get; set; } = 30;
+    protected override int FrameSpeed => 30;
 
     protected override float RetaliationBulletSpeed => 12;
 

--- a/NPCs/Dagoom.cs
+++ b/NPCs/Dagoom.cs
@@ -18,7 +18,7 @@ namespace ChensGradiusMod.NPCs
     private const int SyncRate = 300;
 
     private bool initialized = false;
-    private int yDirection = 0;
+    private sbyte yDirection = 0;
     private int redeployTick = 0;
     private int deployTick = 0;
     private int rushCount = 0;
@@ -60,23 +60,21 @@ namespace ChensGradiusMod.NPCs
 
     public override bool PreAI()
     {
-      if (!initialized)
+      if (GradiusHelper.IsNotMultiplayerClient() && !initialized)
       {
-        initialized = true;
+        npc.netUpdate = initialized = true;
+        yDirection = DecideYDeploy2(npc.height * .3f, CancelDeployThreshold,
+                                    (sbyte)Main.rand.NextBool().ToDirectionInt());
         if (yDirection == 0)
         {
-          yDirection = DecideYDeploy(npc.height * .3f, CancelDeployThreshold);
-          if (yDirection == 0)
-          {
-            npc.active = false;
-            npc.life = 0;
-            return false;
-          }
-          else if (yDirection < 0)
-          {
-            npc.frame.Y = 224;
-            FrameCounter = 4;
-          }
+          npc.active = false;
+          npc.life = 0;
+          return false;
+        }
+        else if (yDirection < 0)
+        {
+          npc.frame.Y = 224;
+          FrameCounter = 4;
         }
       }
 
@@ -150,6 +148,7 @@ namespace ChensGradiusMod.NPCs
 
     public override void SendExtraAI(BinaryWriter writer)
     {
+      base.SendExtraAI(writer);
       writer.Write(yDirection);
       writer.Write((byte)mode);
       writer.Write((byte)oldMode);
@@ -157,6 +156,7 @@ namespace ChensGradiusMod.NPCs
 
     public override void ReceiveExtraAI(BinaryReader reader)
     {
+      base.ReceiveExtraAI(reader);
       yDirection = reader.ReadSByte();
       mode = (States)reader.ReadByte();
       oldMode = (States)reader.ReadByte();
@@ -164,7 +164,7 @@ namespace ChensGradiusMod.NPCs
 
     protected override Types EnemyType => Types.Large;
 
-    protected override int FrameSpeed { get; set; } = 9;
+    protected override int FrameSpeed => 9;
 
     protected override Action<Vector2> RetaliationOverride => RetaliationExplode;
 

--- a/NPCs/Dagoom.cs
+++ b/NPCs/Dagoom.cs
@@ -63,12 +63,11 @@ namespace ChensGradiusMod.NPCs
       if (GradiusHelper.IsNotMultiplayerClient() && !initialized)
       {
         npc.netUpdate = initialized = true;
-        yDirection = DecideYDeploy2(npc.height * .3f, CancelDeployThreshold,
-                                    (sbyte)Main.rand.NextBool().ToDirectionInt());
+        yDirection = DecideYDeploy(npc.height * .3f, CancelDeployThreshold,
+                                   (sbyte)Main.rand.NextBool().ToDirectionInt());
         if (yDirection == 0)
         {
-          npc.active = false;
-          npc.life = 0;
+          Deactivate();
           return false;
         }
         else if (yDirection < 0)
@@ -125,6 +124,7 @@ namespace ChensGradiusMod.NPCs
     {
       if (++FrameTick >= FrameSpeed)
       {
+        FrameTick = 0;
         int limit;
 
         switch (mode)
@@ -140,10 +140,9 @@ namespace ChensGradiusMod.NPCs
             if (--FrameCounter <= limit) mode = States.Standby;
             break;
         }
-
-        npc.frame.Y = FrameCounter * frameHeight;
-        FrameTick = 0;
       }
+
+      npc.frame.Y = FrameCounter * frameHeight;
     }
 
     public override void SendExtraAI(BinaryWriter writer)
@@ -152,6 +151,7 @@ namespace ChensGradiusMod.NPCs
       writer.Write(yDirection);
       writer.Write((byte)mode);
       writer.Write((byte)oldMode);
+      writer.Write(initialized);
     }
 
     public override void ReceiveExtraAI(BinaryReader reader)
@@ -160,6 +160,7 @@ namespace ChensGradiusMod.NPCs
       yDirection = reader.ReadSByte();
       mode = (States)reader.ReadByte();
       oldMode = (States)reader.ReadByte();
+      initialized = reader.ReadBoolean();
     }
 
     protected override Types EnemyType => Types.Large;

--- a/NPCs/Dagoom.cs
+++ b/NPCs/Dagoom.cs
@@ -10,7 +10,6 @@ namespace ChensGradiusMod.NPCs
   public class Dagoom : GradiusEnemy
   {
     private const int PersistDirection = 1;
-    private const int CancelDeployThreshold = 400;
     private const float CustomGravity = 5f;
     private const int RedeployRate = 300;
     private const int DeployRate = 15;
@@ -28,9 +27,9 @@ namespace ChensGradiusMod.NPCs
 
     public enum States { Standby, Open, Deploy, Close };
 
-    public static bool GroundDeploy(NPC npc, ref sbyte yDirection, Vector2 spawnPos,
-                                    int chosenYDir, float yLength, int cancelDeployThreshold,
-                                    Func<float, int, sbyte, bool, sbyte> DecideYDeploy)
+    public static bool GroundDeploy(NPC npc, ref sbyte yDirection, Vector2 spawnPos, int chosenYDir,
+                                    Func<float, int, sbyte, bool, sbyte> DecideYDeploy,
+                                    float yLength = 2f, int cancelDeployThreshold = 500)
     {
       npc.position = spawnPos;
       yDirection = DecideYDeploy(yLength, cancelDeployThreshold, (sbyte)chosenYDir, true);
@@ -76,11 +75,9 @@ namespace ChensGradiusMod.NPCs
         Vector2 spawnPos = npc.position;
 
         npc.netUpdate = initialized = true;
-        GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, npc.height * .3f,
-                     CancelDeployThreshold, DecideYDeploy);
-        if (yDirection == 0 &&
-            !GroundDeploy(npc, ref yDirection, spawnPos, -chosenYDir, npc.height * .3f,
-                          CancelDeployThreshold, DecideYDeploy))
+        GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, DecideYDeploy);
+        if (yDirection == 0 && !GroundDeploy(npc, ref yDirection, spawnPos,
+                                             -chosenYDir, DecideYDeploy))
         {
           Deactivate();
           return false;

--- a/NPCs/Ducker.cs
+++ b/NPCs/Ducker.cs
@@ -141,17 +141,24 @@ namespace ChensGradiusMod.NPCs
     {
       if (GradiusHelper.IsNotMultiplayerClient() && !initialized)
       {
+        int chosenYDir = Main.rand.NextBool().ToDirectionInt();
+        Vector2 spawnPos = npc.position;
+
         npc.netUpdate = initialized = true;
-        npc.TargetClosest(false);
-        if (persistDirection == 0) FaceTarget(Target.Center);
-        yDirection = DecideYDeploy(npc.height * .5f, CancelThreshold,
-                                   (sbyte)Main.rand.NextBool().ToDirectionInt());
-        if (yDirection == 0)
+        Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, npc.height * .5f,
+                            CancelThreshold, DecideYDeploy);
+        if (yDirection == 0 &&
+            !Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, -chosenYDir,
+                                 npc.height * .3f, CancelThreshold, DecideYDeploy))
         {
           Deactivate();
           return false;
         }
+
+        npc.TargetClosest(false);
+        if (persistDirection == 0) FaceTarget(Target.Center);
       }
+
       return initialized;
     }
 

--- a/NPCs/Ducker.cs
+++ b/NPCs/Ducker.cs
@@ -11,7 +11,6 @@ namespace ChensGradiusMod.NPCs
   public class Ducker : GradiusEnemy
   {
     private const float CustomGravity = 8f;
-    private const int CancelThreshold = 500;
     private const float AttackAngleDifference = 7f;
     private const float RunSpeed = 4f;
     private const float FallSpeedYAccel = .5f;
@@ -145,11 +144,9 @@ namespace ChensGradiusMod.NPCs
         Vector2 spawnPos = npc.position;
 
         npc.netUpdate = initialized = true;
-        Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, npc.height * .5f,
-                            CancelThreshold, DecideYDeploy);
-        if (yDirection == 0 &&
-            !Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, -chosenYDir,
-                                 npc.height * .3f, CancelThreshold, DecideYDeploy))
+        Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, DecideYDeploy);
+        if (yDirection == 0 && !Dagoom.GroundDeploy(npc, ref yDirection, spawnPos,
+                                                    -chosenYDir, DecideYDeploy))
         {
           Deactivate();
           return false;

--- a/NPCs/Ducker.cs
+++ b/NPCs/Ducker.cs
@@ -252,6 +252,7 @@ namespace ChensGradiusMod.NPCs
 
     public override void SendExtraAI(BinaryWriter writer)
     {
+      base.SendExtraAI(writer);
       writer.Write((byte)mode);
       writer.Write((byte)oldMode);
       writer.Write(persistDirection);
@@ -263,6 +264,7 @@ namespace ChensGradiusMod.NPCs
 
     public override void ReceiveExtraAI(BinaryReader reader)
     {
+      base.ReceiveExtraAI(reader);
       mode = (States)reader.ReadByte();
       oldMode = (States)reader.ReadByte();
       persistDirection = reader.ReadSByte();
@@ -272,7 +274,7 @@ namespace ChensGradiusMod.NPCs
       numJumps = reader.ReadByte();
     }
 
-    protected override int FrameSpeed { get; set; } = 5;
+    protected override int FrameSpeed => 5;
 
     protected override int FrameCounter { get; set; } = 6;
 

--- a/NPCs/Garun.cs
+++ b/NPCs/Garun.cs
@@ -114,7 +114,7 @@ namespace ChensGradiusMod.NPCs
       timerTick = reader.ReadUInt16();
     }
 
-    protected override int FrameSpeed { get; set; } = 4;
+    protected override int FrameSpeed => 4;
 
     protected override Types EnemyType => Types.Small;
 

--- a/NPCs/GradiusEnemy.cs
+++ b/NPCs/GradiusEnemy.cs
@@ -250,8 +250,8 @@ namespace ChensGradiusMod.NPCs
       }
     }
 
-    protected sbyte DecideYDeploy2(float yLength, int checkLimit, sbyte direction,
-                                   bool moveNpc = true)
+    protected sbyte DecideYDeploy(float yLength, int checkLimit, sbyte direction,
+                                  bool moveNpc = true)
     {
       Vector2 savedP = npc.position,
               movedV = new Vector2(0, yLength * direction),
@@ -273,46 +273,6 @@ namespace ChensGradiusMod.NPCs
       return 0;
     }
 
-    protected sbyte DecideYDeploy(float yLength, int checkLimit, bool moveNpc = true,
-                                  bool forceSpawn = false, sbyte fallbackValue = 0)
-    {
-      Vector2 savedPosition = npc.position,
-              upwardV = new Vector2(0, -yLength),
-              downwardV = new Vector2(0, yLength),
-              upwardP = npc.position,
-              downwardP = npc.position,
-              velocityOnCollide;
-
-      for (int i = 0; i < checkLimit; i++)
-      {
-        velocityOnCollide = Collision.TileCollision(downwardP, downwardV, npc.width, npc.height);
-        if (downwardV != velocityOnCollide)
-        {
-          npc.position = moveNpc ? downwardP : savedPosition;
-          npc.velocity = moveNpc ? velocityOnCollide : Vector2.Zero;
-          return 1;
-        }
-        else downwardP += downwardV;
-
-        velocityOnCollide = Collision.TileCollision(upwardP, upwardV, npc.width, npc.height);
-        if (upwardV != velocityOnCollide)
-        {
-          npc.position = moveNpc ? upwardP : savedPosition;
-          npc.velocity = moveNpc ? velocityOnCollide : Vector2.Zero;
-          return -1;
-        }
-        else upwardP += upwardV;
-      }
-
-      if (!forceSpawn)
-      {
-        npc.friendly = true;
-        npc.active = false;
-        npc.life = 0;
-      }
-      return fallbackValue;
-    }
-
     protected bool ConstantSync(ref int tick, int rate)
     {
       if (GradiusHelper.IsServer())
@@ -326,6 +286,13 @@ namespace ChensGradiusMod.NPCs
       }
 
       return false;
+    }
+
+    protected void Deactivate()
+    {
+      npc.netUpdate = true;
+      npc.active = false;
+      npc.life = 0;
     }
 
     private void ReduceDamage(ref int damage, ref float knockback, ref bool crit)

--- a/NPCs/Grazia.cs
+++ b/NPCs/Grazia.cs
@@ -64,10 +64,15 @@ namespace ChensGradiusMod.NPCs
     {
       if (GradiusHelper.IsNotMultiplayerClient() && !initialized)
       {
+        int chosenYDir = Main.rand.NextBool().ToDirectionInt();
+        Vector2 spawnPos = npc.position;
+
         npc.netUpdate = initialized = true;
-        yDirection = DecideYDeploy(npc.height * .5f, CancelDeployThreshold,
-                                   (sbyte)Main.rand.NextBool().ToDirectionInt());
-        if (yDirection == 0)
+        Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, npc.height * .5f,
+                            CancelDeployThreshold, DecideYDeploy);
+        if (yDirection == 0 &&
+            !Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, -chosenYDir, npc.height * .5f,
+                                 CancelDeployThreshold, DecideYDeploy))
         {
           Deactivate();
           return false;

--- a/NPCs/Grazia.cs
+++ b/NPCs/Grazia.cs
@@ -25,6 +25,7 @@ namespace ChensGradiusMod.NPCs
     private sbyte yDirection = 0;
     private int fireTick = 0;
     private int syncTick = 0;
+    private bool initialized = false;
 
     public override void SetStaticDefaults()
     {
@@ -45,7 +46,6 @@ namespace ChensGradiusMod.NPCs
       npc.defense = 50;
       npc.noGravity = true;
       npc.behindTiles = true;
-      npc.frame.Y = 0;
     }
 
     public override float SpawnChance(NPCSpawnInfo spawnInfo)
@@ -60,21 +60,34 @@ namespace ChensGradiusMod.NPCs
 
     public override string Texture => "ChensGradiusMod/Sprites/Grazia";
 
+    public override bool PreAI()
+    {
+      if (GradiusHelper.IsNotMultiplayerClient() && !initialized)
+      {
+        npc.netUpdate = initialized = true;
+        yDirection = DecideYDeploy(npc.height * .5f, CancelDeployThreshold,
+                                   (sbyte)Main.rand.NextBool().ToDirectionInt());
+        if (yDirection == 0)
+        {
+          Deactivate();
+          return false;
+        }
+        else if (yDirection < 0)
+        {
+          npc.frame.Y = 442;
+          FrameCounter = 13;
+        }
+      }
+
+      return initialized;
+    }
+
     public override void AI()
     {
       npc.direction = npc.spriteDirection = PersistDirection;
 
-      if (yDirection == 0)
-      {
-        yDirection = DecideYDeploy(npc.height * .5f, CancelDeployThreshold);
-        if (yDirection == 0) return;
-        if (yDirection < 0) npc.frame.Y = 416;
-      }
-      else
-      {
-        npc.velocity.Y = CustomGravity * yDirection;
-        npc.velocity = Collision.TileCollision(npc.position, npc.velocity, npc.width, npc.height);
-      }
+      npc.velocity.Y = CustomGravity * yDirection;
+      npc.velocity = Collision.TileCollision(npc.position, npc.velocity, npc.width, npc.height);
 
       if (GradiusHelper.IsNotMultiplayerClient())
       {
@@ -118,12 +131,18 @@ namespace ChensGradiusMod.NPCs
 
     public override void SendExtraAI(BinaryWriter writer)
     {
+      base.SendExtraAI(writer);
       writer.Write(yDirection);
+      writer.Write(initialized);
+      writer.Write((ushort)npc.frame.Y);
     }
 
     public override void ReceiveExtraAI(BinaryReader reader)
     {
+      base.ReceiveExtraAI(reader);
       yDirection = reader.ReadSByte();
+      initialized = reader.ReadBoolean();
+      npc.frame.Y = reader.ReadUInt16();
     }
 
     protected override int RetaliationSpreadBulletNumber => 3;

--- a/NPCs/Grazia.cs
+++ b/NPCs/Grazia.cs
@@ -12,7 +12,6 @@ namespace ChensGradiusMod.NPCs
     private const sbyte PersistDirection = -1;
     private const float CustomGravity = 5f;
     private const int FireRate = 43;
-    private const int CancelDeployThreshold = 500;
     private const int SyncRate = 300;
 
     private readonly int[] directLowerAngleAim = { 0, 21, 41, 61, 81, 100, 120, 140, 160 };
@@ -68,11 +67,9 @@ namespace ChensGradiusMod.NPCs
         Vector2 spawnPos = npc.position;
 
         npc.netUpdate = initialized = true;
-        Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, npc.height * .5f,
-                            CancelDeployThreshold, DecideYDeploy);
-        if (yDirection == 0 &&
-            !Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, -chosenYDir, npc.height * .5f,
-                                 CancelDeployThreshold, DecideYDeploy))
+        Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, DecideYDeploy);
+        if (yDirection == 0 && !Dagoom.GroundDeploy(npc, ref yDirection, spawnPos,
+                                                    -chosenYDir, DecideYDeploy))
         {
           Deactivate();
           return false;

--- a/NPCs/Moai.cs
+++ b/NPCs/Moai.cs
@@ -154,11 +154,13 @@ namespace ChensGradiusMod.NPCs
 
     public override void SendExtraAI(BinaryWriter writer)
     {
+      base.SendExtraAI(writer);
       writer.Write(persistDirection);
     }
 
     public override void ReceiveExtraAI(BinaryReader reader)
     {
+      base.ReceiveExtraAI(reader);
       persistDirection = reader.ReadSByte();
     }
 

--- a/NPCs/Rush.cs
+++ b/NPCs/Rush.cs
@@ -145,7 +145,7 @@ namespace ChensGradiusMod.NPCs
       oldMode = (States)reader.ReadByte();
     }
 
-    protected override int FrameSpeed { get; set; } = 3;
+    protected override int FrameSpeed => 3;
 
     protected override Types EnemyType => Types.Small;
 

--- a/NPCs/Rush.cs
+++ b/NPCs/Rush.cs
@@ -57,9 +57,8 @@ namespace ChensGradiusMod.NPCs
 
         if (persistDirection == 0)
         {
+          Deactivate();
           initialized = false;
-          npc.active = false;
-          npc.life = 0;
         }
         else initialized = true;
       }

--- a/NPCs/Sagna.cs
+++ b/NPCs/Sagna.cs
@@ -9,7 +9,6 @@ namespace ChensGradiusMod.NPCs
 {
   public class Sagna : GradiusEnemy
   {
-    private const int CancelDeployThreshold = 500;
     private const float XSpeed = 3f;
     private const float YGravity = .1f;
     private const float MaxYSpeed = 5f;
@@ -78,11 +77,9 @@ namespace ChensGradiusMod.NPCs
         Vector2 spawnPos = npc.position;
 
         npc.netUpdate = initialized = true;
-        Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, npc.height * .5f,
-                            CancelDeployThreshold, DecideYDeploy);
-        if (yDirection == 0 && 
-            !Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, npc.height * .5f,
-                                 CancelDeployThreshold, DecideYDeploy))
+        Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, DecideYDeploy);
+        if (yDirection == 0 && !Dagoom.GroundDeploy(npc, ref yDirection, spawnPos,
+                                                    -chosenYDir, DecideYDeploy))
         {
           Deactivate();
           return false;
@@ -108,7 +105,7 @@ namespace ChensGradiusMod.NPCs
     {
       npc.spriteDirection = npc.direction = persistDirection;
 
-      if (npc.position == npc.oldPosition)
+      if (npc.position == npc.oldPosition && mode != States.Spray)
       {
         if (++unstuckTick >= UnstuckTime)
         {

--- a/NPCs/Sagna.cs
+++ b/NPCs/Sagna.cs
@@ -142,6 +142,7 @@ namespace ChensGradiusMod.NPCs
 
     public override void SendExtraAI(BinaryWriter writer)
     {
+      base.SendExtraAI(writer);
       writer.Write(animateDirection);
       writer.Write((byte)mode);
       writer.Write((byte)oldMode);
@@ -155,6 +156,7 @@ namespace ChensGradiusMod.NPCs
 
     public override void ReceiveExtraAI(BinaryReader reader)
     {
+      base.ReceiveExtraAI(reader);
       animateDirection = reader.ReadSByte();
       mode = (States)reader.ReadByte();
       oldMode = (States)reader.ReadByte();
@@ -172,7 +174,7 @@ namespace ChensGradiusMod.NPCs
 
     protected override float RetaliationSpreadAngleDifference => 180f;
 
-    protected override int FrameSpeed { get; set; } = 6;
+    protected override int FrameSpeed => 6;
 
     private void MoveHorizontally()
     {

--- a/NPCs/Sagna.cs
+++ b/NPCs/Sagna.cs
@@ -74,10 +74,15 @@ namespace ChensGradiusMod.NPCs
     {
       if (GradiusHelper.IsNotMultiplayerClient() && !initialized)
       {
+        int chosenYDir = Main.rand.NextBool().ToDirectionInt();
+        Vector2 spawnPos = npc.position;
+
         npc.netUpdate = initialized = true;
-        yDirection = DecideYDeploy(npc.height * .5f, CancelDeployThreshold,
-                                   (sbyte)Main.rand.NextBool().ToDirectionInt());
-        if (yDirection == 0)
+        Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, npc.height * .5f,
+                            CancelDeployThreshold, DecideYDeploy);
+        if (yDirection == 0 && 
+            !Dagoom.GroundDeploy(npc, ref yDirection, spawnPos, chosenYDir, npc.height * .5f,
+                                 CancelDeployThreshold, DecideYDeploy))
         {
           Deactivate();
           return false;
@@ -89,6 +94,7 @@ namespace ChensGradiusMod.NPCs
           maxFrame = (byte)Main.npcFrameCount[npc.type];
           FrameCounter = startFrame;
         }
+
         npc.TargetClosest(false);
         if (npc.Center.X > Main.player[npc.target].Center.X) persistDirection = -1;
         else persistDirection = 1;

--- a/NPCs/Zalk.cs
+++ b/NPCs/Zalk.cs
@@ -132,7 +132,7 @@ namespace ChensGradiusMod.NPCs
       oldMode = (States)reader.ReadByte();
     }
 
-    protected override int FrameSpeed { get; set; } = 3;
+    protected override int FrameSpeed => 3;
 
     protected override Types EnemyType => Types.Small;
 


### PR DESCRIPTION
Add more custom variables for syncing to improve multiplayer experience.

Allow enemies to spawn as a vertically inversed version of themselves.